### PR TITLE
added ghex devhelp gnome-disk-utility totem cheese now you can build gnome-clocks

### DIFF
--- a/cheese/PKGBUILD
+++ b/cheese/PKGBUILD
@@ -1,0 +1,49 @@
+# Maintainer: Fabian Bornschein <fabiscafe-cat-mailbox-dog-org>
+# Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+options=(debug !strip)
+
+pkgname=cheese
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="Take photos and videos with your webcam, with fun graphical effects"
+url="https://wiki.gnome.org/Apps/Cheese"
+arch=(x86_64)
+license=(GPL)
+depends=(gtk3 gstreamer gst-plugins-bad gst-plugins-base gst-plugins-good clutter-gst clutter-gtk
+         libcanberra librsvg gnome-desktop libgudev dconf gnome-video-effects)
+makedepends=(gobject-introspection vala git appstream-glib meson yelp-tools)
+checkdepends=(xorg-server-xvfb)
+groups=(gnome)
+conflicts=(libcheese cheese)
+replaces=(libcheese cheese)
+provides=(libcheese cheese)
+_commit=9d06f5841f0aca52a458db197cb904819e448911 # tags/43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/cheese.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+}
+
+build() {
+  arch-meson $pkgname build
+  meson compile -C build
+}
+
+check() (
+  glib-compile-schemas "${GSETTINGS_SCHEMA_DIR:=$PWD/cheese/data}"
+  export GSETTINGS_SCHEMA_DIR
+
+  dbus-run-session xvfb-run -s '-nolisten local' \
+    meson test -C build --print-errorlogs
+)
+
+package() {
+  DESTDIR="$pkgdir" meson install -C build
+}

--- a/devhelp/PKGBUILD
+++ b/devhelp/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Link Dupont <link@subpop.net>
+
+pkgbase=devhelp
+pkgname=(devhelp devhelp-docs)
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="API documentation browser for GNOME"
+url="https://wiki.gnome.org/Apps/Devhelp"
+arch=(x86_64)
+license=(GPL)
+depends=(webkit2gtk)
+makedepends=(git appstream-glib gobject-introspection meson yelp-tools
+             gi-docgen)
+options=(debug)
+_commit=35fa56d628d640859f80710b614cb9e1e7ac9299  # tag 43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/devhelp.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd devhelp
+  git describe --tags | sed 's/\.alpha/alpha/;s/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd devhelp
+}
+
+build() {
+  arch-meson devhelp build \
+    -D gtk_doc=true \
+    -D plugin_emacs=true \
+    -D plugin_gedit=true \
+    -D plugin_vim=true
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package_devhelp() {
+  groups=(gnome-extra)
+
+  meson install -C build --destdir "$pkgdir"
+
+  # Split -docs
+  mkdir -p docs/usr/share
+  mv -t docs/usr/share "$pkgdir"/usr/share/doc
+}
+
+package_devhelp-docs() {
+  pkgdesc+=" (documentation)"
+  depends=()
+
+  mv -t "$pkgdir" docs/*
+}

--- a/ghex/PKGBUILD
+++ b/ghex/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Tobias Kieslich <tobias@justdreams.de>
+
+pkgbase=ghex
+pkgname=(ghex ghex-docs)
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="A simple binary editor for the Gnome desktop"
+url="https://wiki.gnome.org/Apps/Ghex"
+arch=(x86_64)
+license=(GPL)
+depends=(gtk4)
+makedepends=(git meson yelp-tools gobject-introspection gi-docgen)
+options=(debug)
+_commit=79f4e2e465d46fe999374bf194fd81c4fa84f9a6  # tags/43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/ghex.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd ghex
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd ghex
+}
+
+build() {
+  arch-meson ghex build -D gtk_doc=true
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package_ghex() {
+  provides=(libgtkhex-4.so)
+  groups=(gnome-extra)
+
+  meson install -C build --destdir "$pkgdir"
+
+  mkdir -p doc/usr/share
+  mv {"$pkgdir",doc}/usr/share/doc
+}
+
+package_ghex-docs() {
+  pkgdesc+=" (documentation)"
+  depends=()
+
+  mv doc/* "$pkgdir"
+}

--- a/gnome-clocks/PKGBUILD
+++ b/gnome-clocks/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+
+pkgname=gnome-clocks
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="Clocks applications for GNOME"
+url="https://wiki.gnome.org/Apps/Clocks"
+arch=(x86_64)
+license=(GPL)
+depends=(gtk4 libgweather-4 gnome-desktop-4 geoclue geocode-glib gsound
+         libadwaita)
+makedepends=(vala gobject-introspection yelp-tools git meson)
+groups=(gnome)
+options=(debug)
+_commit=608366fdcb320d90b6ecd32d819aa31efdae5ba7  # tags/43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/gnome-clocks.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+}
+
+build() {
+  arch-meson $pkgname build
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+}

--- a/gnome-disk-utility/PKGBUILD
+++ b/gnome-disk-utility/PKGBUILD
@@ -1,0 +1,38 @@
+# Maintainer: Fabian Bornschein <fabiscafe-cat-mailbox-dog-org>
+# Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+# Contributor: Silvio Knizek (killermoehre)
+options=(debug)
+
+pkgname=gnome-disk-utility
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="Disk Management Utility for GNOME"
+url="https://gitlab.gnome.org/GNOME/gnome-disk-utility"
+arch=(x86_64)
+license=(GPL)
+groups=(gnome)
+depends=(udisks2 libsecret libpwquality libcanberra libdvdread libnotify
+         parted systemd libhandy)
+makedepends=(git meson docbook-xsl)
+_commit=1ffa4315fcd3b7cacaad8b666a1018bf5a2b6f9d  # tag/43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/gnome-disk-utility.git#commit=$_commit")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
+}
+
+build() {
+  arch-meson $pkgname build
+  meson compile -C build
+}
+
+check() {
+  meson test -C build --print-errorlogs
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+}

--- a/totem/PKGBUILD
+++ b/totem/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Fabian Bornschein <fabiscafe-cat-mailbox-dog-org>
+# Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
+# Contributor: Jan de Groot <jgc@archlinux.org>
+options=(debug)
+
+pkgname=totem
+pkgver=43.alpha
+pkgrel=1
+pkgdesc="Movie player for the GNOME desktop based on GStreamer"
+url="https://wiki.gnome.org/Apps/Videos"
+arch=(x86_64)
+license=(GPL2 custom)
+depends=(totem-plparser iso-codes libhandy libpeas grilo
+         gsettings-desktop-schemas dconf python-gobject python-xdg gnome-desktop
+         gst-plugins-base gst-plugins-good gst-plugins-bad gst-plugin-gtk)
+makedepends=(libnautilus-extension itstool docbook-xsl python-pylint
+             gobject-introspection git appstream-glib gtk-doc meson intltool)
+optdepends=('gst-plugins-ugly: Extra media codecs'
+            'gst-libav: Extra media codecs'
+            'grilo-plugins: Media discovery'
+            'python-dbus: MPRIS plugin')
+groups=(gnome)
+conflicts=(totem-plugin)
+replaces=(totem-plugin)
+_commit=0061ec01460dfb582a65b83198263d33555fc08b  # tags/43.alpha^0
+source=("git+https://gitlab.gnome.org/GNOME/totem.git#commit=$_commit"
+        "git+https://gitlab.gnome.org/GNOME/libgd.git")
+sha256sums=('SKIP'
+            'SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags | sed 's/-/+/g'
+}
+
+prepare() {
+  cd $pkgname
+
+  git submodule init
+  git submodule set-url subprojects/libgd "$srcdir/libgd"
+  git submodule update
+}
+
+build() {
+  arch-meson $pkgname build \
+    -D enable-gtk-doc=true
+  meson compile -C build
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+  install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 $pkgname/COPYING
+}

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -9,6 +9,7 @@
 - devhelp 43.alpha
 - ghex 43.alpha
 - totem 43.alpha
+- cheese 43.alpha
 - eog 43.alpha
 - epiphany 43.alpha
 - evolution 3.45.1

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -19,6 +19,7 @@
 - gjs 1.73.1
 - glib2 2.73.2
 - glib-networking 2.74.alpha
+- gnome-clocks 43.alpha
 - gnome-calculator 43.alpha
 - gnome-calendar 43.alpha
 - gnome-calls 43.alpha2
@@ -81,12 +82,6 @@ cc -Isrc/plugins/git/daemon/gnome-builder-git.p -Isrc/plugins/git/daemon -I../gn
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       |          GGIT_STATUS_WORKING_TREE_TYPECHANGE
 ```
-- gnome-clocks
-
-```
-error: Package 'geocode-glib-2.0' not found in specified Vala API directories or GObject-Introspection GIR directories
-```
-
 
 ## Exclude
 - none

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -8,6 +8,7 @@
 - d-spy 1.2.1
 - devhelp 43.alpha
 - ghex 43.alpha
+- totem 43.alpha
 - eog 43.alpha
 - epiphany 43.alpha
 - evolution 3.45.1

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -6,6 +6,7 @@
 - clapper 0.5.2
 - dconf-editor 43.alpha
 - d-spy 1.2.1
+- ghex 43.alpha
 - eog 43.alpha
 - epiphany 43.alpha
 - evolution 3.45.1

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -42,6 +42,7 @@
 - gnome-software 43.alpha
 - gnome-text-editor 43.alpha0
 - gnome-weather 43.alpha
+- gnome-disk-utility 43.alpha
 - gobject-introspection 1.73.0
 - gsettings-desktop-schemas 43.alpha
 - gtk4 4.7.1

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -6,6 +6,7 @@
 - clapper 0.5.2
 - dconf-editor 43.alpha
 - d-spy 1.2.1
+- devhelp 43.alpha
 - ghex 43.alpha
 - eog 43.alpha
 - epiphany 43.alpha

--- a/version-tracking.md
+++ b/version-tracking.md
@@ -87,6 +87,30 @@ cc -Isrc/plugins/git/daemon/gnome-builder-git.p -Isrc/plugins/git/daemon -I../gn
       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       |          GGIT_STATUS_WORKING_TREE_TYPECHANGE
 ```
+- evince
+
+```
+FAILED: properties/libevince-properties-page.so.p/ev-properties-main.c.o 
+cc -Iproperties/libevince-properties-page.so.p -Iproperties -I../evince/properties -I. -I../evince -Ilibdocument -I../evince/libdocument -I/usr/include/cairo -I/usr/include/lzo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-4 -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/gio-unix-2.0 -I/usr/include/cloudproviders -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/libxml2 -I/usr/include/synctex -I/usr/include/nautilus -I/usr/include/gtk-4.0 -I/usr/include/graphene-1.0 -I/usr/lib/graphene-1.0/include -fvisibility=hidden -flto=auto -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -DHAVE_CONFIG_H -Wno-deprecated-declarations -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/home/zombie/gnome-unstable/evince/src=/usr/src/debug -fPIC -mfpmath=sse -msse -msse2 -pthread -MD -MQ properties/libevince-properties-page.so.p/ev-properties-main.c.o -MF properties/libevince-properties-page.so.p/ev-properties-main.c.o.d -o properties/libevince-properties-page.so.p/ev-properties-main.c.o -c ../evince/properties/ev-properties-main.c
+../evince/properties/ev-properties-main.c:44:10: error: unknown type name ‘NautilusPropertyPageProviderIface’; did you mean ‘NautilusPropertyPageProviderInterface’?
+   44 |         (NautilusPropertyPageProviderIface *iface);
+      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |          NautilusPropertyPageProviderInterface
+../evince/properties/ev-properties-main.c: In function ‘ev_properties_plugin_register_type’:
+../evince/properties/ev-properties-main.c:63:37: error: ‘property_page_provider_iface_init’ undeclared (first use in this function); did you mean ‘property_page_provider_iface_info’?
+   63 |                 (GInterfaceInitFunc)property_page_provider_iface_init,
+      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                     property_page_provider_iface_info
+../evince/properties/ev-properties-main.c:63:37: note: each undeclared identifier is reported only once for each function it appears in
+../evince/properties/ev-properties-main.c: At top level:
+../evince/properties/ev-properties-main.c:78:36: error: unknown type name ‘NautilusPropertyPageProviderIface’; did you mean ‘NautilusPropertyPageProviderInterface’?
+   78 | property_page_provider_iface_init (NautilusPropertyPageProviderIface *iface)
+      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                                    NautilusPropertyPageProviderInterface
+../evince/properties/ev-properties-main.c:84:1: warning: ‘ev_properties_get_pages’ defined but not used [-Wunused-function]
+   84 | ev_properties_get_pages (NautilusPropertyPageProvider *provider,
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+```
 
 ## Exclude
 - none


### PR DESCRIPTION
Now gnome-clocks buildable
evince wontbuildable
gnome-boxes build works but wont open throws error so I dont add
```
(process:32982): libsoup-ERROR **: 00:15:21.393: libsoup3 symbols detected. Using libsoup2 and libsoup3 in the same process is not supported.
zsh: trace trap (core dumped)  gnome-boxes
```

add these packages because cheese totem and gnome-clocks is broken

if there is any problem feel free to discouse about